### PR TITLE
Link to the Array API standard page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,11 @@ pygmentsUseClasses = true
     name = "Blog"
     weight = -100
     url = "/blog/"
+    
+[[menu.main]]
+    name = "Array API"
+    weight = -100
+    url = "https://data-apis.org/array-api/latest/"
 
 # To render raw html tags within Markdown
 [markup.goldmark.renderer]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,6 +6,9 @@
           <a href="/blog/">Blog</a>
         </li>
         <li>
+          <a href="https://data-apis.org/array-api/latest/">Array API</a>
+        </li>
+        <li>
           <a href="https://github.com/data-apis">GitHub</a>
         </li>
           <li>


### PR DESCRIPTION
Currently if I am on https://data-apis.org/, it takes two clicks to jump to the standard's page (draft array API standard -> document). This PR adds links on the top bar and footer so that it becomes more obvious.