### PR TITLE
Update links to point to main instead of master

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,10 +12,10 @@
           <a href="https://github.com/data-apis">GitHub</a>
         </li>
           <li>
-          <a href="https://github.com/data-apis/governance/blob/master/consortium_governance.md">Governance</a>
+          <a href="https://github.com/data-apis/governance/blob/main/consortium_governance.md">Governance</a>
         </li>
           <li>
-          <a href="https://github.com/data-apis/.github/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a>
+          <a href="https://github.com/data-apis/.github/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
The 2 Github links in the footer pointed to branches named `master`, which seem to have been renamed to `main`.