### PR TITLE
Fix an incorrect statement in the latest blog post 

### DIFF
--- a/content/blog/array_api_v2022_release.md
+++ b/content/blog/array_api_v2022_release.md
@@ -88,7 +88,7 @@ their own libraries and device support steadily increased.
 
 During our work on the 2021 revision, standardizing complex number behavior was
 one of the top requests from the community; however, array libraries, such as
-CuPy and PyTorch, were still in the process of adding full complex number
+PyTorch, were still in the process of adding full complex number
 support across their APIs. Given the still evolving landscape across the
 ecosystem, we wanted to avoid prematurely constraining API design before full
 consideration of the real-world experience gained while attempting to support


### PR DESCRIPTION
Sorry I didn't notice the blog post was out until today, so I couldn't help proofread... 

CuPy already had full complex number support on par with NumPy's for a very long time, way before 2021, so this should be fixed. (As a matter of fact, lack of complex number support was one of the my driving factors 🙂)